### PR TITLE
Support fedora-like filesystem structure

### DIFF
--- a/tool/taffo/taffo.sh
+++ b/tool/taffo/taffo.sh
@@ -20,6 +20,9 @@ taffo_setenv_find()
   fi
 
   PATH="$BASEDIR/$2/$FN"
+  if [[ ! -e $PATH ]] && [[ $2 == 'lib' ]]; then
+    PATH="$BASEDIR/${2}64/$FN"
+  fi
 
   if [[ ! -e "$PATH" ]]; then
     echo "Cannot find $FN" >> $LOG


### PR DESCRIPTION
Fedora, RHEL, CentOS, openSUSE use `$PREFIX/lib64` for 64-bit libraries.
Indeed cmake installs `Taffo.so` in `$CMAKE_INSTALL_PREFIX/lib64`