### PR TITLE
Update or-tools

### DIFF
--- a/cmake/TaffoFetchDeps.cmake
+++ b/cmake/TaffoFetchDeps.cmake
@@ -13,7 +13,7 @@ if (TAFFO_BUILD_ILP_DTA)
     FetchContent_Declare(
       or-tools
       GIT_REPOSITORY "https://github.com/google/or-tools.git"
-      GIT_TAG "v9.4"
+      GIT_TAG "v9.6"
       GIT_SHALLOW ON
       GIT_PROGRESS ON)
     # TODO: disable some of this stuff, not sure we need it all
@@ -29,7 +29,7 @@ if (TAFFO_BUILD_ILP_DTA)
     set(BUILD_CXX_SAMPLES OFF)
     set(BUILD_CXX_EXAMPLES OFF)
     FetchContent_GetProperties(or-tools)
-    if(NOT cmark_POPULATED)
+    if(NOT or-tools_POPULATED)
       FetchContent_Populate(or-tools)
       add_subdirectory(${or-tools_SOURCE_DIR} ${or-tools_BINARY_DIR} EXCLUDE_FROM_ALL)
     endif()

--- a/test-lit/CMakeLists.txt
+++ b/test-lit/CMakeLists.txt
@@ -7,6 +7,6 @@ configure_lit_site_cfg(
 set(TAFFO_TEST_DEPENDS
     Taffo)
 
-add_lit_testsuite(check "Running the regression tests"
+add_lit_testsuite(taffo-check-lit "Running the regression tests"
     ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${TAFFO_TEST_DEPENDS})


### PR DESCRIPTION
Older or-tools fail to build with libstdc++ 13

Need to rename the 'check' target because it conflicts with some target with the same name pulled in by or-tools