### PR TITLE
tool: Allow cxx file extension

### DIFF
--- a/tool/taffo/taffo.sh
+++ b/tool/taffo/taffo.sh
@@ -254,7 +254,7 @@ for opt in $raw_opts; do
         *.c | *.ll)
           input_files+=( "$opt" );
           ;;
-        *.cpp | *.cc)
+        *.cpp | *.cc | *.cxx)
           input_files+=( "$opt" );
           AUTO_CLANGXX=$CLANGXX
           ;;


### PR DESCRIPTION
".cxx" is a known c++ extension.
It is used by CMake to test the compiler.