### PR TITLE
Fix usage of nonexistent `llvm/actions/*` actions in CI

### DIFF
--- a/.github/workflows/llvm-setup.yml
+++ b/.github/workflows/llvm-setup.yml
@@ -49,13 +49,10 @@ jobs:
           max-size: 500M
           key: sccache-ubuntu-latest
           variant: sccache
-          
+
       - name: Fetch LLVM
         if: steps.llvm-cache.outputs.cache-hit != 'true'
-        uses: llvm/actions/get-llvm-project-src/@main
-        with:
-          ref: 3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff
-          repo: llvm/llvm-project
+        run: git clone https://github.com/llvm/llvm-project.git --branch llvmorg-18.1.8 --depth 1 --single-branch /home/runner/llvm
 
       - name: Build and Test
         if: steps.llvm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/llvm-setup.yml
+++ b/.github/workflows/llvm-setup.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Fetch LLVM
         if: steps.llvm-cache.outputs.cache-hit != 'true'
-        run: git clone https://github.com/llvm/llvm-project.git --branch llvmorg-18.1.8 --depth 1 --single-branch /home/runner/llvm
+        run: git clone https://github.com/llvm/llvm-project.git --branch release/18.x --depth 1 --single-branch /home/runner/llvm
 
       - name: Build and Test
         if: steps.llvm-cache.outputs.cache-hit != 'true'
@@ -61,7 +61,7 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         run: |
-          cmake -S llvm -B build -GNinja -DCMAKE_INSTALL_PREFIX="$HOME/llvm" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake -S llvm -B build -GNinja -DCMAKE_INSTALL_PREFIX="/home/runner/llvm" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           cmake --build build -j $(nproc) -- install
 
       - name: Cache

--- a/.github/workflows/llvm-setup.yml
+++ b/.github/workflows/llvm-setup.yml
@@ -56,14 +56,13 @@ jobs:
 
       - name: Build and Test
         if: steps.llvm-cache.outputs.cache-hit != 'true'
-        uses: llvm/actions/build-test-llvm-project@main
         env:
           # Workaround for https://github.com/actions/virtual-environments/issues/5900.
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
-        with:
-          cmake_args: '-GNinja -DCMAKE_INSTALL_PREFIX="$HOME/llvm" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
-          build_target: 'install'
+        run: |
+          cmake -S llvm -B build -GNinja -DCMAKE_INSTALL_PREFIX="$HOME/llvm" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake --build build -j $(nproc) -- install
 
       - name: Cache
         if: steps.llvm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/llvm-setup.yml
+++ b/.github/workflows/llvm-setup.yml
@@ -61,8 +61,8 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         run: |
-          cmake -S llvm -B build -GNinja -DCMAKE_INSTALL_PREFIX="/home/runner/llvm" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build build -j $(nproc) -- install
+          cmake -S /home/runner/llvm/llvm -B /home/runner/llvm/build -GNinja -DCMAKE_INSTALL_PREFIX="/home/runner/llvm/install" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake --build /home/runner/llvm/build -j $(nproc) -- install
 
       - name: Cache
         if: steps.llvm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/llvm-setup.yml
+++ b/.github/workflows/llvm-setup.yml
@@ -61,7 +61,7 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         run: |
-          cmake -S /home/runner/llvm/llvm -B /home/runner/llvm/build -GNinja -DCMAKE_INSTALL_PREFIX="/home/runner/llvm/install" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake -S /home/runner/llvm/llvm -B /home/runner/llvm/build -GNinja -DCMAKE_INSTALL_PREFIX="/home/runner/llvm/install" -DLLVM_ENABLE_PROJECTS="clang;openmp" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           cmake --build /home/runner/llvm/build -j $(nproc) -- install
 
       - name: Cache

--- a/.github/workflows/llvm-setup.yml
+++ b/.github/workflows/llvm-setup.yml
@@ -52,7 +52,10 @@ jobs:
 
       - name: Fetch LLVM
         if: steps.llvm-cache.outputs.cache-hit != 'true'
-        run: git clone https://github.com/llvm/llvm-project.git --branch release/18.x --depth 1 --single-branch /home/runner/llvm
+        run: |
+          wget https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz
+          mkdir -p /home/runner/llvm
+          tar xzf llvmorg-18.1.8.tar.gz -C /home/runner/llvm --strip-components=1
 
       - name: Build and Test
         if: steps.llvm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/taffo-build-and-test.yml
+++ b/.github/workflows/taffo-build-and-test.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DLLVM_DIR="/home/runner/llvm" -DCMAKE_PREFIX_PATH="/home/runner/ortools"
+      run: cmake -B ${{github.workspace}}/build -DLLVM_DIR="/home/runner/llvm/install" -DCMAKE_PREFIX_PATH="/home/runner/ortools"
 
     - name: Build
       # Build your program with the given configuration
@@ -68,7 +68,7 @@ jobs:
 
     - name: Test
       env:
-        LD_LIBRARY_PATH: /home/runner/ortools/lib:/home/runner/llvm/lib
+        LD_LIBRARY_PATH: /home/runner/ortools/lib:/home/runner/llvm/install/lib
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail


### PR DESCRIPTION
In particular,
- replaced `llvm/actions/get-llvm-project-src` with an explicit `wget`
- replaced `llvm/actions/build-test-llvm-project` with CMake commands
